### PR TITLE
Fix for ticket #45907. Twenty Nineteen: Right-aligned, uncaptioned im…

### DIFF
--- a/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
+++ b/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
@@ -89,6 +89,24 @@
 	}
 }
 
+.entry-content > p > img {
+
+	&.alignright {
+			/*rtl:ignore*/
+			float: right;
+			max-width: calc(5 * (100vw / 12));
+			margin-top: 0;
+			margin-right: 0;
+			/*rtl:ignore*/
+			margin-left: $size__spacing-unit;
+
+			@include media(desktop) {
+				position: absolute;
+				left: calc(7.5 * (100vw / 12));
+			}
+		}
+}
+
 .entry .entry-content > *,
 .entry .entry-summary > * {
 

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -5354,6 +5354,23 @@ body.page .main-navigation {
   }
 }
 
+.entry-content > p > img.alignright {
+  /*rtl:ignore*/
+  float: right;
+  max-width: calc(5 * (100vw / 12));
+  margin-top: 0;
+  margin-right: 0;
+  /*rtl:ignore*/
+  margin-left: 1rem;
+}
+
+@media only screen and (min-width: 1168px) {
+  .entry-content > p > img.alignright {
+    position: absolute;
+    left: calc(7.5 * (100vw / 12));
+  }
+}
+
 .entry .entry-content > * > *:first-child,
 .entry .entry-summary > * > *:first-child {
   margin-top: 0;


### PR DESCRIPTION
Fix for ticket #45907. Twenty Nineteen: Right-aligned, uncaptioned images inserted via the Classic Editor do not extend beyond the text column.
I modify src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss to uncaptioned images inserted via the Classic Editor looks like captioned ones.